### PR TITLE
Modification that shows that enabling TRACE logging results in NPE.

### DIFF
--- a/src/main/java/com/mapr/db/samples/basic/Ex01SimpleCRUD.java
+++ b/src/main/java/com/mapr/db/samples/basic/Ex01SimpleCRUD.java
@@ -20,6 +20,9 @@ package com.mapr.db.samples.basic;
 import com.mapr.db.MapRDB;
 import com.mapr.db.Table;
 import com.mapr.db.samples.basic.model.User;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.ojai.Document;
 import org.ojai.DocumentStream;
 import org.ojai.store.DocumentMutation;
@@ -52,10 +55,10 @@ public class Ex01SimpleCRUD {
   }
 
   public static void main(String[] args) throws Exception {
-
+    BasicConfigurator.configure();
+    Logger.getRootLogger().setLevel(Level.TRACE);
     Ex01SimpleCRUD app = new Ex01SimpleCRUD();
     app.run();
-
   }
 
   private void run() throws Exception {


### PR DESCRIPTION
If TRACE logging is enabled, then the query functions throw NPE in Inode.

```
Exception in thread "main" java.lang.NullPointerException
	at java.lang.System.arraycopy(Native Method)
	at com.mapr.fs.Inode.addToScanCache(Inode.java:1417)
	at com.mapr.fs.Inode.scanNext(Inode.java:1521)
	at com.mapr.fs.MapRHTable.scanNext(MapRHTable.java:755)
	at com.mapr.fs.MapRResultScanner.nextRows(MapRResultScanner.java:58)
	at com.mapr.fs.MapRResultScanner.nextRows(MapRResultScanner.java:51)
	at com.mapr.fs.MapRResultScanner.nextRow(MapRResultScanner.java:38)
	at com.mapr.db.ojai.DBDocumentStream.next(DBDocumentStream.java:112)
	at com.mapr.db.ojai.DBDocumentStream.access$100(DBDocumentStream.java:28)
	at com.mapr.db.ojai.DBDocumentStream$1.hasNext(DBDocumentStream.java:192)
	at com.mapr.db.samples.basic.Ex01SimpleCRUD.queryDocuments(Ex01SimpleCRUD.java:290)
	at com.mapr.db.samples.basic.Ex01SimpleCRUD.run(Ex01SimpleCRUD.java:75)
	at com.mapr.db.samples.basic.Ex01SimpleCRUD.main(Ex01SimpleCRUD.java:61)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```
